### PR TITLE
Fix value encoding

### DIFF
--- a/coco/coco.go
+++ b/coco/coco.go
@@ -406,9 +406,6 @@ func Encode(packet collectd.Packet) []byte {
 		valueBytes := new(bytes.Buffer)
 
 		switch v.Type {
-		case collectd.TypeGauge:
-			gauge := float64(v.Value)
-			binary.Write(valueBytes, binary.LittleEndian, gauge)
 		case collectd.TypeAbsolute:
 			absolute := uint64(v.Value)
 			binary.Write(valueBytes, binary.BigEndian, absolute)
@@ -418,6 +415,9 @@ func Encode(packet collectd.Packet) []byte {
 		case collectd.TypeDerive:
 			derive := int64(v.Value)
 			binary.Write(valueBytes, binary.BigEndian, derive)
+		case collectd.TypeGauge:
+			gauge := float64(v.Value)
+			binary.Write(valueBytes, binary.LittleEndian, gauge)
 		default:
 			binary.Write(valueBytes, binary.BigEndian, v.Value)
 		}

--- a/coco/coco.go
+++ b/coco/coco.go
@@ -409,9 +409,15 @@ func Encode(packet collectd.Packet) []byte {
 		case collectd.TypeGauge:
 			gauge := float64(v.Value)
 			binary.Write(valueBytes, binary.LittleEndian, gauge)
+		case collectd.TypeAbsolute:
+			absolute := uint64(v.Value)
+			binary.Write(valueBytes, binary.BigEndian, absolute)
 		case collectd.TypeCounter:
 			counter := uint64(v.Value)
 			binary.Write(valueBytes, binary.BigEndian, counter)
+		case collectd.TypeDerive:
+			derive := int64(v.Value)
+			binary.Write(valueBytes, binary.BigEndian, derive)
 		default:
 			binary.Write(valueBytes, binary.BigEndian, v.Value)
 		}

--- a/coco/coco_test.go
+++ b/coco/coco_test.go
@@ -279,7 +279,6 @@ func TestSendEncodeCounter(t *testing.T) {
 
 	// Setup sender
 	tierConfig := make(map[string]coco.TierConfig)
-	//tierConfig["a"] = coco.TierConfig{Targets: []string{"127.0.0.1:25960"}}
 	tierConfig["a"] = coco.TierConfig{Targets: []string{listenConfig.Bind}}
 
 	var tiers []coco.Tier
@@ -337,7 +336,7 @@ func TestSendEncodeCounter(t *testing.T) {
 func TestSendEncodeGauge(t *testing.T) {
 	// Setup listen
 	listenConfig := coco.ListenConfig{
-		Bind:    "127.0.0.1:25960",
+		Bind:    "127.0.0.1:25961",
 		Typesdb: "../types.db",
 	}
 	raw := make(chan collectd.Packet, 500)
@@ -345,7 +344,6 @@ func TestSendEncodeGauge(t *testing.T) {
 
 	// Setup sender
 	tierConfig := make(map[string]coco.TierConfig)
-	//tierConfig["a"] = coco.TierConfig{Targets: []string{"127.0.0.1:25960"}}
 	tierConfig["a"] = coco.TierConfig{Targets: []string{listenConfig.Bind}}
 
 	var tiers []coco.Tier

--- a/coco/coco_test.go
+++ b/coco/coco_test.go
@@ -268,7 +268,73 @@ func TestSend(t *testing.T) {
 	}
 }
 
-func TestSendEncoding(t *testing.T) {
+func TestSendEncodeCounter(t *testing.T) {
+	// Setup listen
+	listenConfig := coco.ListenConfig{
+		Bind:    "127.0.0.1:25960",
+		Typesdb: "../types.db",
+	}
+	raw := make(chan collectd.Packet, 500)
+	go coco.Listen(listenConfig, raw)
+
+	// Setup sender
+	tierConfig := make(map[string]coco.TierConfig)
+	//tierConfig["a"] = coco.TierConfig{Targets: []string{"127.0.0.1:25960"}}
+	tierConfig["a"] = coco.TierConfig{Targets: []string{listenConfig.Bind}}
+
+	var tiers []coco.Tier
+	for k, v := range tierConfig {
+		tier := coco.Tier{Name: k, Targets: v.Targets}
+		tiers = append(tiers, tier)
+	}
+
+	filtered := make(chan collectd.Packet)
+	go coco.Send(&tiers, filtered)
+
+	// Dispatch a sample
+	value := collectd.Value{
+		Name:  "value",
+		Type:  uint8(0),
+		Value: 161797775,
+	}
+	sample := collectd.Packet{
+		Hostname:       "foo",
+		Plugin:         "cpu",
+		PluginInstance: "0",
+		Type:           "cpu",
+		TypeInstance:   "idle",
+		Interval:       10,
+		Time:           uint64(time.Now().Unix()),
+		Values:         []collectd.Value{value},
+	}
+	filtered <- sample
+
+	// Breathe a moment so packet works its way through
+	time.Sleep(100 * time.Millisecond)
+	if len(raw) != 1 {
+		t.Errorf("Expected %d packets, got %d\n", 1, len(raw))
+		t.FailNow()
+	}
+
+	// Grab a sample
+	s := <-raw
+	if len(s.Values) != 1 {
+		t.Errorf("Expected %d values in sample, got %d\n", 1, len(s.Values))
+		t.FailNow()
+	}
+
+	v := s.Values[0]
+	t.Logf("%+v\n", v)
+	t.Logf("%+v\n", value)
+	t.Logf("%+v\n", v.Value == value.Value)
+
+	if value.Value != v.Value {
+		t.Errorf("Expected value to be %f, got %f\n", value.Value, v.Value)
+		t.FailNow()
+	}
+}
+
+func TestSendEncodeGauge(t *testing.T) {
 	// Setup listen
 	listenConfig := coco.ListenConfig{
 		Bind:    "127.0.0.1:25960",

--- a/coco/coco_test.go
+++ b/coco/coco_test.go
@@ -268,7 +268,70 @@ func TestSend(t *testing.T) {
 	}
 }
 
-func TestSendEncodeCounter(t *testing.T) {
+func TestEncodeAbsolute(t *testing.T) {
+	// Setup listen
+	listenConfig := coco.ListenConfig{
+		Bind:    "127.0.0.1:25963",
+		Typesdb: "../types.db",
+	}
+	raw := make(chan collectd.Packet, 500)
+	go coco.Listen(listenConfig, raw)
+
+	// Setup sender
+	tierConfig := make(map[string]coco.TierConfig)
+	tierConfig["a"] = coco.TierConfig{Targets: []string{listenConfig.Bind}}
+
+	var tiers []coco.Tier
+	for k, v := range tierConfig {
+		tier := coco.Tier{Name: k, Targets: v.Targets}
+		tiers = append(tiers, tier)
+	}
+
+	filtered := make(chan collectd.Packet)
+	go coco.Send(&tiers, filtered)
+
+	// Dispatch a sample
+	value := collectd.Value{
+		Name:     "value",
+		Type:     uint8(3),
+		TypeName: "absolute",
+		Value:    5,
+	}
+	sample := collectd.Packet{
+		Hostname: "foo",
+		Plugin:   "processes",
+		Type:     "absolute",
+		Interval: 10,
+		Time:     uint64(time.Now().Unix()),
+		Values:   []collectd.Value{value},
+	}
+	filtered <- sample
+
+	// Breathe a moment so packet works its way through
+	time.Sleep(100 * time.Millisecond)
+	if len(raw) != 1 {
+		t.Errorf("Expected %d packets, got %d\n", 1, len(raw))
+		t.FailNow()
+	}
+
+	// Grab a sample
+	s := <-raw
+	if len(s.Values) != 1 {
+		t.Errorf("Expected %d values in sample, got %d\n", 1, len(s.Values))
+		t.FailNow()
+	}
+
+	v := s.Values[0]
+	t.Logf("before: %+v\n", value)
+	t.Logf("after:  %+v\n", v)
+
+	if value.Value != v.Value {
+		t.Errorf("Expected value to be %d, got %d\n", value.Value, v.Value)
+		t.FailNow()
+	}
+}
+
+func TestEncodeCounter(t *testing.T) {
 	// Setup listen
 	listenConfig := coco.ListenConfig{
 		Bind:    "127.0.0.1:25960",
@@ -333,70 +396,7 @@ func TestSendEncodeCounter(t *testing.T) {
 	}
 }
 
-func TestSendEncodeGauge(t *testing.T) {
-	// Setup listen
-	listenConfig := coco.ListenConfig{
-		Bind:    "127.0.0.1:25961",
-		Typesdb: "../types.db",
-	}
-	raw := make(chan collectd.Packet, 500)
-	go coco.Listen(listenConfig, raw)
-
-	// Setup sender
-	tierConfig := make(map[string]coco.TierConfig)
-	tierConfig["a"] = coco.TierConfig{Targets: []string{listenConfig.Bind}}
-
-	var tiers []coco.Tier
-	for k, v := range tierConfig {
-		tier := coco.Tier{Name: k, Targets: v.Targets}
-		tiers = append(tiers, tier)
-	}
-
-	filtered := make(chan collectd.Packet)
-	go coco.Send(&tiers, filtered)
-
-	// Dispatch a sample
-	value := collectd.Value{
-		Name:     "shortterm",
-		Type:     uint8(1),
-		TypeName: "gauge",
-		Value:    0.5,
-	}
-	sample := collectd.Packet{
-		Hostname: "foo",
-		Plugin:   "load",
-		Type:     "load",
-		Interval: 10,
-		Time:     uint64(time.Now().Unix()),
-		Values:   []collectd.Value{value},
-	}
-	filtered <- sample
-
-	// Breathe a moment so packet works its way through
-	time.Sleep(100 * time.Millisecond)
-	if len(raw) != 1 {
-		t.Errorf("Expected %d packets, got %d\n", 1, len(raw))
-		t.FailNow()
-	}
-
-	// Grab a sample
-	s := <-raw
-	if len(s.Values) != 1 {
-		t.Errorf("Expected %d values in sample, got %d\n", 1, len(s.Values))
-		t.FailNow()
-	}
-
-	v := s.Values[0]
-	t.Logf("before: %+v\n", value)
-	t.Logf("after:  %+v\n", v)
-
-	if value.Value != v.Value {
-		t.Errorf("Expected value to be %d, got %d\n", value.Value, v.Value)
-		t.FailNow()
-	}
-}
-
-func TestSendEncodeDerive(t *testing.T) {
+func TestEncodeDerive(t *testing.T) {
 	// Setup listen
 	listenConfig := coco.ListenConfig{
 		Bind:    "127.0.0.1:25962",
@@ -459,10 +459,10 @@ func TestSendEncodeDerive(t *testing.T) {
 	}
 }
 
-func TestSendEncodeAbsolute(t *testing.T) {
+func TestEncodeGauge(t *testing.T) {
 	// Setup listen
 	listenConfig := coco.ListenConfig{
-		Bind:    "127.0.0.1:25963",
+		Bind:    "127.0.0.1:25961",
 		Typesdb: "../types.db",
 	}
 	raw := make(chan collectd.Packet, 500)
@@ -483,15 +483,15 @@ func TestSendEncodeAbsolute(t *testing.T) {
 
 	// Dispatch a sample
 	value := collectd.Value{
-		Name:     "value",
-		Type:     uint8(3),
-		TypeName: "absolute",
-		Value:    5,
+		Name:     "shortterm",
+		Type:     uint8(1),
+		TypeName: "gauge",
+		Value:    0.5,
 	}
 	sample := collectd.Packet{
 		Hostname: "foo",
-		Plugin:   "processes",
-		Type:     "absolute",
+		Plugin:   "load",
+		Type:     "load",
 		Interval: 10,
 		Time:     uint64(time.Now().Unix()),
 		Values:   []collectd.Value{value},

--- a/coco/coco_test.go
+++ b/coco/coco_test.go
@@ -292,9 +292,10 @@ func TestSendEncodeCounter(t *testing.T) {
 
 	// Dispatch a sample
 	value := collectd.Value{
-		Name:  "value",
-		Type:  uint8(0),
-		Value: 161797775,
+		Name:     "value",
+		Type:     uint8(0),
+		TypeName: "counter",
+		Value:    161797775,
 	}
 	sample := collectd.Packet{
 		Hostname:       "foo",
@@ -323,9 +324,8 @@ func TestSendEncodeCounter(t *testing.T) {
 	}
 
 	v := s.Values[0]
-	t.Logf("%+v\n", v)
-	t.Logf("%+v\n", value)
-	t.Logf("%+v\n", v.Value == value.Value)
+	t.Logf("before: %+v\n", value)
+	t.Logf("after:  %+v\n", v)
 
 	if value.Value != v.Value {
 		t.Errorf("Expected value to be %f, got %f\n", value.Value, v.Value)
@@ -357,9 +357,10 @@ func TestSendEncodeGauge(t *testing.T) {
 
 	// Dispatch a sample
 	value := collectd.Value{
-		Name:  "shortterm",
-		Type:  uint8(1),
-		Value: 0.5,
+		Name:     "shortterm",
+		Type:     uint8(1),
+		TypeName: "gauge",
+		Value:    0.5,
 	}
 	sample := collectd.Packet{
 		Hostname: "foo",
@@ -386,9 +387,8 @@ func TestSendEncodeGauge(t *testing.T) {
 	}
 
 	v := s.Values[0]
-	t.Logf("%+v\n", v)
-	t.Logf("%+v\n", value)
-	t.Logf("%+v\n", v.Value == value.Value)
+	t.Logf("before: %+v\n", value)
+	t.Logf("after:  %+v\n", v)
 
 	if value.Value != v.Value {
 		t.Errorf("Expected value to be %d, got %d\n", value.Value, v.Value)

--- a/coco/coco_test.go
+++ b/coco/coco_test.go
@@ -396,6 +396,132 @@ func TestSendEncodeGauge(t *testing.T) {
 	}
 }
 
+func TestSendEncodeDerive(t *testing.T) {
+	// Setup listen
+	listenConfig := coco.ListenConfig{
+		Bind:    "127.0.0.1:25962",
+		Typesdb: "../types.db",
+	}
+	raw := make(chan collectd.Packet, 500)
+	go coco.Listen(listenConfig, raw)
+
+	// Setup sender
+	tierConfig := make(map[string]coco.TierConfig)
+	tierConfig["a"] = coco.TierConfig{Targets: []string{listenConfig.Bind}}
+
+	var tiers []coco.Tier
+	for k, v := range tierConfig {
+		tier := coco.Tier{Name: k, Targets: v.Targets}
+		tiers = append(tiers, tier)
+	}
+
+	filtered := make(chan collectd.Packet)
+	go coco.Send(&tiers, filtered)
+
+	// Dispatch a sample
+	value := collectd.Value{
+		Name:     "value",
+		Type:     uint8(2),
+		TypeName: "derive",
+		Value:    1392536,
+	}
+	sample := collectd.Packet{
+		Hostname: "foo",
+		Plugin:   "processes",
+		Type:     "fork_rate",
+		Interval: 10,
+		Time:     uint64(time.Now().Unix()),
+		Values:   []collectd.Value{value},
+	}
+	filtered <- sample
+
+	// Breathe a moment so packet works its way through
+	time.Sleep(100 * time.Millisecond)
+	if len(raw) != 1 {
+		t.Errorf("Expected %d packets, got %d\n", 1, len(raw))
+		t.FailNow()
+	}
+
+	// Grab a sample
+	s := <-raw
+	if len(s.Values) != 1 {
+		t.Errorf("Expected %d values in sample, got %d\n", 1, len(s.Values))
+		t.FailNow()
+	}
+
+	v := s.Values[0]
+	t.Logf("before: %+v\n", value)
+	t.Logf("after:  %+v\n", v)
+
+	if value.Value != v.Value {
+		t.Errorf("Expected value to be %d, got %d\n", value.Value, v.Value)
+		t.FailNow()
+	}
+}
+
+func TestSendEncodeAbsolute(t *testing.T) {
+	// Setup listen
+	listenConfig := coco.ListenConfig{
+		Bind:    "127.0.0.1:25963",
+		Typesdb: "../types.db",
+	}
+	raw := make(chan collectd.Packet, 500)
+	go coco.Listen(listenConfig, raw)
+
+	// Setup sender
+	tierConfig := make(map[string]coco.TierConfig)
+	tierConfig["a"] = coco.TierConfig{Targets: []string{listenConfig.Bind}}
+
+	var tiers []coco.Tier
+	for k, v := range tierConfig {
+		tier := coco.Tier{Name: k, Targets: v.Targets}
+		tiers = append(tiers, tier)
+	}
+
+	filtered := make(chan collectd.Packet)
+	go coco.Send(&tiers, filtered)
+
+	// Dispatch a sample
+	value := collectd.Value{
+		Name:     "value",
+		Type:     uint8(3),
+		TypeName: "absolute",
+		Value:    5,
+	}
+	sample := collectd.Packet{
+		Hostname: "foo",
+		Plugin:   "processes",
+		Type:     "absolute",
+		Interval: 10,
+		Time:     uint64(time.Now().Unix()),
+		Values:   []collectd.Value{value},
+	}
+	filtered <- sample
+
+	// Breathe a moment so packet works its way through
+	time.Sleep(100 * time.Millisecond)
+	if len(raw) != 1 {
+		t.Errorf("Expected %d packets, got %d\n", 1, len(raw))
+		t.FailNow()
+	}
+
+	// Grab a sample
+	s := <-raw
+	if len(s.Values) != 1 {
+		t.Errorf("Expected %d values in sample, got %d\n", 1, len(s.Values))
+		t.FailNow()
+	}
+
+	v := s.Values[0]
+	t.Logf("before: %+v\n", value)
+	t.Logf("after:  %+v\n", v)
+
+	if value.Value != v.Value {
+		t.Errorf("Expected value to be %d, got %d\n", value.Value, v.Value)
+		t.FailNow()
+	}
+}
+
 func TestSendTiers(t *testing.T) {
 	// Setup listen
 	listenConfig := coco.ListenConfig{


### PR DESCRIPTION
This PR fixes value encoding for counter, derive, and absolute value types. 

Currently in master they are encoded as float64, which is incorrect per [collectd's binary protocol documentation](https://collectd.org/wiki/index.php/Binary_protocol#Value_parts). 

This PR correctly encodes absolute as uint64, counters as uint64, derive as int64. 